### PR TITLE
add spree_api_v1 dependency since it was extracted out of spree

### DIFF
--- a/lib/spree/frontend/engine.rb
+++ b/lib/spree/frontend/engine.rb
@@ -1,3 +1,4 @@
+require 'spree_api_v1'
 require_relative 'configuration'
 
 module Spree

--- a/spree_frontend.gemspec
+++ b/spree_frontend.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_api', ">= #{s.version}"
   s.add_dependency 'spree_core', ">= #{s.version}"
+  s.add_dependency 'spree_api_v1', ">= 4.5.0"
 
   s.add_dependency 'babel-transpiler', '~> 0.7'
   s.add_dependency 'bootstrap',       '~> 4.0'


### PR DESCRIPTION
this gem doesn't work without spree_api_v1

PS: I intentionally used >= 4.5.0, as I predict the spree_api_v1 may not be updated anymore with new releases of other gems (e.g. 4.6.0).
PS2: The require in the engine was necessary after moving this into gem as dependency. When I had spree_api_v1 in my project Gemfile, that was not needed. Probably has to do with load order and rails engine/initializer order.