### PR TITLE
Translations support

### DIFF
--- a/app/controllers/spree/products_controller.rb
+++ b/app/controllers/spree/products_controller.rb
@@ -52,7 +52,7 @@ module Spree
     end
 
     def load_product
-      @product = current_store.products.for_user(try_spree_current_user).friendly.find(params[:id])
+      @product = find_with_fallback_default_locale { current_store.products.for_user(try_spree_current_user).friendly.find(params[:id]) }
     end
 
     def load_taxon

--- a/app/controllers/spree/taxons_controller.rb
+++ b/app/controllers/spree/taxons_controller.rb
@@ -30,7 +30,7 @@ module Spree
     end
 
     def load_taxon
-      @taxon = current_store.taxons.friendly.find(params[:id])
+      @taxon = find_with_fallback_default_locale { current_store.taxons.friendly.find(params[:id]) }
     end
 
     def load_products


### PR DESCRIPTION
This PR adds a basic support for translated Product and Taxons entities.
- Added fallback support for products that don't have translated permalinks
- Added redirects to a translated permalink when switching locale