### PR TITLE
Use logo_attachment in logo helper

### DIFF
--- a/app/helpers/spree/frontend_helper.rb
+++ b/app/helpers/spree/frontend_helper.rb
@@ -18,7 +18,7 @@ module Spree
       image_path ||= if logo_attachment&.attached? && logo_attachment&.variable?
                        main_app.cdn_image_url(logo_attachment.variant(resize: '244x104>'))
                      elsif logo_attachment&.attached? && logo_attachment&.image?
-                       main_app.cdn_image_url(current_store.logo)
+                       main_app.cdn_image_url(logo_attachment)
                      else
                        asset_path('logo/spree_50.png')
                      end


### PR DESCRIPTION
### Summary
In Spree 4.5 support for `Spree::StoreLogo` was introduced, however, this object's particularities were not taken into account to render images without variants.

### Additional information
Former implementation was not supporting svg logos.