### PR TITLE
fixed: don't overwrite the manifest.js file during installation

### DIFF
--- a/lib/generators/spree/frontend/install/install_generator.rb
+++ b/lib/generators/spree/frontend/install/install_generator.rb
@@ -23,8 +23,6 @@ module Spree
           directory 'homepage', './app/assets/images/homepage'
           # SCSS theming
           template 'variables.scss', './app/assets/stylesheets/spree/frontend/variables/variables.scss'
-          # Sprockets 4 manifest
-          template 'app/assets/config/manifest.js', force: Rails.env.test?
           # home page template
           directory 'home', './app/views/spree/home'
         end

--- a/lib/generators/spree/frontend/install/templates/app/assets/config/manifest.js
+++ b/lib/generators/spree/frontend/install/templates/app/assets/config/manifest.js
@@ -1,2 +1,0 @@
-//= link_tree ../images
-//= link_directory ../stylesheets .css


### PR DESCRIPTION
this isn't needed anymore