### PR TITLE
Use Spree::Money to format non shipment tax on _summary.html.erb

### DIFF
--- a/app/views/spree/checkout/_summary.html.erb
+++ b/app/views/spree/checkout/_summary.html.erb
@@ -17,7 +17,7 @@
       <div class="d-table-cell text-right"
            data-hook='tax-total'
            data-currency='<%= Money::Currency.find(order.currency).symbol %>'
-           data-non-shipment-tax='<%= adjustments.reject{ |adj| adj.adjustable_type== 'Spree::Shipment'}.sum(&:amount) %>'
+           data-non-shipment-tax='<%= Spree::Money.new(adjustments.reject{ |adj| adj.adjustable_type== 'Spree::Shipment'}.sum(&:amount), currency: order.currency) %>'
            thousands-separator='<%= tax_total.thousands_separator %>'
            decimal-mark='<%= tax_total.decimal_mark %>'
            precision='<%= Money::Currency.find(order.currency).exponent %>'>


### PR DESCRIPTION
Slack conversation context:

> hey! I have a weird case in which [this line](https://github.com/spree/spree_rails_frontend/blob/main/app/views/spree/checkout/_summary.html.erb#L20) produces wrong data-non-shipment-tax value. Instead of it heaving 69,0 or 69 value, it contains 69.0 value which breaks javascript part of that screen - the javascript parses it into 690 which completely breaks all the calculations. Is that a known issue? What would be the best way to approach that? As a hotfix, i can simply make sure 69.0 is being transformed to 69,0 with a simple gsub or using Spree::Money with proper options passed into but i want to make sure that's a good and safe way of doing that